### PR TITLE
Update README to include prerequisite .NET 4.6.2 Developer Pack for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ cd Workshop
 - [Git Client](https://git-scm.com/downloads)
 - [.NET Core SDK 1.1](https://www.microsoft.com/net/download/core#/current)
 - [Visual Studio Code](https://code.visualstudio.com/) or [Visual Studio 2017]( https://www.visualstudio.com/downloads/ )
+- [.NET 4.6.2 Developer Pack (Windows requirement for building with .NET 4.x)](https://support.microsoft.com/en-us/help/3151934/microsoft-.net-framework-4.6.2-developer-pack-and-language-packs)
 - [Visual Studio 2017 .NET Core Workload](https://www.microsoft.com/net/core#windowsvs2017)
 
 


### PR DESCRIPTION
This fixes a bug with Lab05 when using a fresh install of VS Community Edition 2017.

The `dotnet run -f net462` command would fail on Lab05 with a message
about needing the 4.6.2 framework. I reproduced the error on a fresh
Windows 7 install with VS2017 Community. Before installing, the error
occurred. After installing and opening a fresh command window, the
app runs successfully.