### PR TITLE
URL Cleanup

### DIFF
--- a/Final/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Final/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/Lab01/CloudFoundry/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab01/CloudFoundry/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab05/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab05/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab06/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab06/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab07/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab07/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab08/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab08/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab09/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab09/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab10/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab10/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Lab11/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Lab11/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {

--- a/Start/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
+++ b/Start/Fortune-Teller-UI/wwwroot/lib/jquery-validation/dist/additional-methods.js
@@ -247,7 +247,7 @@ $.validator.addMethod("cpfBR", function(value) {
 }, "Please specify a valid CPF number");
 
 /* NOTICE: Modified version of Castle.Components.Validator.CreditCardValidator
- * Redistributed under the the Apache License 2.0 at http://www.apache.org/licenses/LICENSE-2.0
+ * Redistributed under the the Apache License 2.0 at https://www.apache.org/licenses/LICENSE-2.0
  * Valid Types: mastercard, visa, amex, dinersclub, enroute, discover, jcb, unknown, all (overrides all other settings)
  */
 $.validator.addMethod("creditcardtypes", function(value, element, param) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 11 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).